### PR TITLE
fix: support the alternate lambda client name 

### DIFF
--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -109,3 +109,9 @@ def test_change_boto_kwargs_on_existing():
     # Make sure they equal but are NOT the same exact dict (should be a copy)
     assert current_boto_kwargs == set_with_boto_kwargs
     assert current_boto_kwargs is not set_with_boto_kwargs
+
+
+def test_get_lambda_client():
+    from xboto import BotoClients
+    BotoClients.grab().load('lambda_')
+

--- a/xboto/dependencies.py
+++ b/xboto/dependencies.py
@@ -273,6 +273,10 @@ class _BaseBotoClientOrResource(Dependency):
         boto_name = boto_name.replace("_", "-")
         boto_name = boto_name.lower()
 
+        if boto_name.endswith("-"):
+            # Remove ending underscore (ie: for the `lambda_` name).
+            boto_name = boto_name[:-1]
+
         if dep_cls := _dependency_classes[boto_kind].get(boto_name):
             return dep_cls
 


### PR DESCRIPTION
(due to python keyword conflict)